### PR TITLE
FOGL-10184: set output to integer if input, Scale Factor and Offset are all integers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ When adding a scale filter to either the south service or north task, via the *A
 | |scale| |
 +---------+
 
-The configuration options supported by the scale filter are detailed in the table below
+The configuration options supported by the scale filter are detailed in the table below:
 
 +-----------------+------------------------------------------------------------------+
 | Setting         | Description                                                      |
@@ -21,8 +21,19 @@ The configuration options supported by the scale filter are detailed in the tabl
 +-----------------+------------------------------------------------------------------+
 | Constant Offset | A constant to add to all numeric values after applying the scale |
 +-----------------+------------------------------------------------------------------+
-| Asset filter    | This is useful when applying the filter in the north, it allows  |
-|                 | the filter to be applied only to those assets that match the     |
-|                 | regular expression given. If left blank then the filter is       |
-|                 | applied to all assets/                                           |
+| Asset filter    | A regular expression to apply to the asset name.                 |
+|                 | If configured, the filter will be applied only to those assets   |
+|                 | that match the expression.                                       |
+|                 | If blank, the filter will be applied to all assets.              |
+|                 | This is useful when applying the filter in the north.            |
 +-----------------+------------------------------------------------------------------+
+
+Output Data Types
+-----------------
+
+If filter input values are integers and the *Scale Factor* and *Constant Offset* are both integers, the outputs will be integers.
+
+If filter input values, *Scale Factor* or *Constant Offset* are floating point values, the outputs will be floating point values.
+
+For non-numeric input values, *Scale Factor* and *Constant Offset* cannot be applied.
+The filter output value will match the input value.

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -140,6 +140,8 @@ void plugin_ingest(PLUGIN_HANDLE *handle,
 	{
 		offset = strtod(filter->getConfig().getValue("offset").c_str(), NULL);
 	}
+	bool integerFactors = (scaleFactor == floor(scaleFactor)) && (offset == floor(offset));
+
 	string match;
 	regex  *re = 0;
 	if (filter->getConfig().itemExists("match"))
@@ -189,13 +191,14 @@ void plugin_ingest(PLUGIN_HANDLE *handle,
 			if (value.getType() == DatapointValue::T_INTEGER)
 			{
 				double newValue = value.toInt() * scaleFactor + offset;
-				if (newValue == floor(newValue))
+
+				if (integerFactors)
 				{
-					value.setValue(newValue);
+					value.setValue((long)newValue);
 				}
 				else
 				{
-					value.setValue((long)newValue);
+					value.setValue(newValue);
 				}
 			}
 			else if (value.getType() == DatapointValue::T_FLOAT)

--- a/tests/test_info.cpp
+++ b/tests/test_info.cpp
@@ -15,7 +15,7 @@ TEST(SCALE_INFO, PluginInfo)
 {
 	PLUGIN_INFORMATION *info = plugin_info();
 	ASSERT_STREQ(info->name, "scale");
-	ASSERT_EQ(info->type, PLUGIN_TYPE_FILTER);
+	ASSERT_STREQ(info->type, PLUGIN_TYPE_FILTER);
 }
 
 TEST(SCALE_INFO, PluginInfoConfigParse)

--- a/tests/test_scale.cpp
+++ b/tests/test_scale.cpp
@@ -62,13 +62,93 @@ TEST(SCALE, ScaleInteger)
 	ASSERT_EQ(points.size(), 1);
 	Datapoint *outdp = points[0];
 	ASSERT_STREQ(outdp->getName().c_str(), "test");
-	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_FLOAT);
-	ASSERT_EQ(outdp->getData().toDouble(), 4.0);
+	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
+	ASSERT_EQ(outdp->getData().toInt(), 4);
 
 	delete config;
 	plugin_shutdown(handle);
 }
 
+TEST(SCALE, ScaleFactorFloat)
+{
+	PLUGIN_INFORMATION *info = plugin_info();
+	ConfigCategory *config = new ConfigCategory("scale", info->config);
+	ASSERT_NE(config, (ConfigCategory *)NULL);
+	config->setItemsValueFromDefault();
+	ASSERT_EQ(config->itemExists("factor"), true);
+	config->setValue("factor", "1.9");
+	config->setValue("enable", "true");
+	ReadingSet *outReadings;
+	void *handle = plugin_init(config, &outReadings, Handler);
+	vector<Reading *> *readings = new vector<Reading *>;
+
+	long testValue = 2;
+	DatapointValue dpv(testValue);
+	Datapoint *value = new Datapoint("test", dpv);
+	Reading *in = new Reading("test", value);
+	readings->push_back(in);
+
+	ReadingSet readingSet(readings);
+	delete readings;
+	plugin_ingest(handle, (READINGSET *)&readingSet);
+
+
+	vector<Reading *>results = outReadings->getAllReadings();
+	ASSERT_EQ(results.size(), 1);
+	Reading *out = results[0];
+	ASSERT_STREQ(out->getAssetName().c_str(), "test");
+	ASSERT_EQ(out->getDatapointCount(), 1);
+	vector<Datapoint *> points = out->getReadingData();
+	ASSERT_EQ(points.size(), 1);
+	Datapoint *outdp = points[0];
+	ASSERT_STREQ(outdp->getName().c_str(), "test");
+	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_FLOAT);
+	ASSERT_EQ(outdp->getData().toDouble(), 3.8);
+
+	delete config;
+	plugin_shutdown(handle);
+}
+
+TEST(SCALE, ScaleOffsetFloat)
+{
+	PLUGIN_INFORMATION *info = plugin_info();
+	ConfigCategory *config = new ConfigCategory("scale", info->config);
+	ASSERT_NE(config, (ConfigCategory *)NULL);
+	config->setItemsValueFromDefault();
+	ASSERT_EQ(config->itemExists("factor"), true);
+	config->setValue("factor", "2");
+	config->setValue("offset", "0.1");
+	config->setValue("enable", "true");
+	ReadingSet *outReadings;
+	void *handle = plugin_init(config, &outReadings, Handler);
+	vector<Reading *> *readings = new vector<Reading *>;
+
+	long testValue = 2;
+	DatapointValue dpv(testValue);
+	Datapoint *value = new Datapoint("test", dpv);
+	Reading *in = new Reading("test", value);
+	readings->push_back(in);
+
+	ReadingSet readingSet(readings);
+	delete readings;
+	plugin_ingest(handle, (READINGSET *)&readingSet);
+
+
+	vector<Reading *>results = outReadings->getAllReadings();
+	ASSERT_EQ(results.size(), 1);
+	Reading *out = results[0];
+	ASSERT_STREQ(out->getAssetName().c_str(), "test");
+	ASSERT_EQ(out->getDatapointCount(), 1);
+	vector<Datapoint *> points = out->getReadingData();
+	ASSERT_EQ(points.size(), 1);
+	Datapoint *outdp = points[0];
+	ASSERT_STREQ(outdp->getName().c_str(), "test");
+	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_FLOAT);
+	ASSERT_EQ(outdp->getData().toDouble(), 4.1);
+
+	delete config;
+	plugin_shutdown(handle);
+}
 
 TEST(SCALE, ScaleDouble)
 {
@@ -242,8 +322,8 @@ TEST(SCALE, ScaleMultiDP)
 		}
 		else if (outdp->getName().compare("integer") == 0)
 		{
-			ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_FLOAT);
-			ASSERT_EQ(outdp->getData().toDouble(), 20.0);
+			ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
+			ASSERT_EQ(outdp->getData().toInt(), 20);
 		}
 	}
 
@@ -306,8 +386,8 @@ TEST(SCALE, ScaleOffsetMultiDP)
 		}
 		else if (outdp->getName().compare("integer") == 0)
 		{
-			ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_FLOAT);
-			ASSERT_EQ(outdp->getData().toDouble(), 120.0);
+			ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
+			ASSERT_EQ(outdp->getData().toInt(), 120);
 		}
 	}
 
@@ -369,8 +449,8 @@ TEST(SCALE, ScaleNegativeOffsetMultiDP)
 		}
 		else if (outdp->getName().compare("integer") == 0)
 		{
-			ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_FLOAT);
-			ASSERT_EQ(outdp->getData().toDouble(), 14.0);
+			ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
+			ASSERT_EQ(outdp->getData().toInt(), 14);
 		}
 	}
 

--- a/tests/test_scale.cpp
+++ b/tests/test_scale.cpp
@@ -65,7 +65,6 @@ TEST(SCALE, ScaleInteger)
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_FLOAT);
 	ASSERT_EQ(outdp->getData().toDouble(), 4.0);
 
-	delete outReadings;
 	delete config;
 	plugin_shutdown(handle);
 }
@@ -107,7 +106,6 @@ TEST(SCALE, ScaleDouble)
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_FLOAT);
 	ASSERT_EQ(outdp->getData().toDouble(), 3.0);
 
-	delete outReadings;
 	delete config;
 	plugin_shutdown(handle);
 }
@@ -147,7 +145,6 @@ TEST(SCALE, ScaleDisabled)
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_INTEGER);
 	ASSERT_EQ(outdp->getData().toInt(), 2);
 
-	delete outReadings;
 	delete config;
 	plugin_shutdown(handle);
 }
@@ -188,7 +185,6 @@ TEST(SCALE, ScaleString)
 	ASSERT_EQ(outdp->getData().getType(), DatapointValue::T_STRING);
 	ASSERT_STREQ(outdp->getData().toStringValue().c_str(), "Untouched");
 
-	delete outReadings;
 	delete config;
 	plugin_shutdown(handle);
 }
@@ -251,7 +247,6 @@ TEST(SCALE, ScaleMultiDP)
 		}
 	}
 
-	delete outReadings;
 	delete config;
 	plugin_shutdown(handle);
 }
@@ -316,7 +311,6 @@ TEST(SCALE, ScaleOffsetMultiDP)
 		}
 	}
 
-	delete outReadings;
 	delete config;
 	plugin_shutdown(handle);
 }
@@ -380,7 +374,6 @@ TEST(SCALE, ScaleNegativeOffsetMultiDP)
 		}
 	}
 
-	delete outReadings;
 	delete config;
 	plugin_shutdown(handle);
 }
@@ -477,7 +470,6 @@ TEST(SCALE, ScaleMatch)
 		}
 	}
 
-	delete outReadings;
 	delete config;
 	plugin_shutdown(handle);
 }


### PR DESCRIPTION
Set output to integer if input, *Scale Factor* and *Offset* are all integers. All other combinations of numeric data types produce floating point values. Added tests to confirm this behavior. Added *Output Data Types* subsection to the documentation to make this clear.

This should help resolve reported bugs [FOGL-9728](https://scaledb.atlassian.net/browse/[FOGL-9728](https://scaledb.atlassian.net/browse/FOGL-9728)) and [FOGL-10184](https://scaledb.atlassian.net/browse/[FOGL-10184](https://scaledb.atlassian.net/browse/FOGL-10184)) which reported errors in northbound data flow to OMF North caused by an unexpected switch in data type from integer to float when the Scale Filter was introduced into a working pipeline.

**Note:** this is a change in behavior for the Scale Filter. In the past, the Scale Filter would always produce floating point numbers.